### PR TITLE
add testnet env

### DIFF
--- a/.env.cross_testnet
+++ b/.env.cross_testnet
@@ -1,0 +1,43 @@
+# Set of ENVs for Arbitrum One network explorer
+# https://arbitrum.blockscout.com
+# This is an auto-generated file. To update all values, run "yarn dev:preset:sync --name=arbitrum"
+
+# Local ENVs
+NEXT_PUBLIC_APP_PROTOCOL=http
+NEXT_PUBLIC_APP_HOST=localhost
+NEXT_PUBLIC_APP_PORT=3000
+NEXT_PUBLIC_APP_ENV=development
+NEXT_PUBLIC_API_WEBSOCKET_PROTOCOL=ws
+
+# Instance ENVs
+NEXT_PUBLIC_API_BASE_PATH=/
+NEXT_PUBLIC_API_HOST=blockscout.crossops.in
+NEXT_PUBLIC_API_SPEC_URL=https://raw.githubusercontent.com/blockscout/blockscout-api-v2-swagger/main/swagger.yaml
+# NEXT_PUBLIC_CONTRACT_CODE_IDES=[{'title':'Remix IDE','url':'https://remix.ethereum.org/?address={hash}&blockscout={domain}','icon_url':'https://raw.githubusercontent.com/blockscout/frontend-configs/main/configs/ide-icons/remix.png'}]
+# NEXT_PUBLIC_CONTRACT_INFO_API_HOST=https://contracts-info.services.blockscout.com
+# NEXT_PUBLIC_GRAPHIQL_TRANSACTION=0x37c798810d49ba132b40efe7f4fdf6806a8fc58226bb5e185ddc91f896577abf
+NEXT_PUBLIC_HOMEPAGE_CHARTS=['daily_txs']
+# NEXT_PUBLIC_HOMEPAGE_PLATE_BACKGROUND=rgba(27, 74, 221, 1)
+# NEXT_PUBLIC_IS_ACCOUNT_SUPPORTED=true
+# NEXT_PUBLIC_LOGOUT_URL=https://blockscout-arbitrum.us.auth0.com/v2/logout
+# NEXT_PUBLIC_MARKETPLACE_ENABLED=false
+# NEXT_PUBLIC_METADATA_SERVICE_API_HOST=https://metadata.services.blockscout.com
+NEXT_PUBLIC_NETWORK_CURRENCY_DECIMALS=18
+NEXT_PUBLIC_NETWORK_CURRENCY_NAME=ETH
+NEXT_PUBLIC_NETWORK_CURRENCY_SYMBOL=ETH
+# NEXT_PUBLIC_NETWORK_EXPLORERS=[{'title':'GeckoTerminal','logo':'https://raw.githubusercontent.com/blockscout/frontend-configs/main/configs/explorer-logos/geckoterminal.png','baseUrl':'https://www.geckoterminal.com/','paths':{'token':'/arbitrum/pools'}}]
+NEXT_PUBLIC_NETWORK_ICON=/images/custom-network-icon.svg
+# NEXT_PUBLIC_NETWORK_ICON_DARK=https://raw.githubusercontent.com/blockscout/frontend-configs/main/configs/network-icons/arbitrum-one-icon-dark.svg
+NEXT_PUBLIC_NETWORK_ID=611044
+# NEXT_PUBLIC_NETWORK_LOGO=https://raw.githubusercontent.com/blockscout/frontend-configs/main/configs/network-logos/arbitrum-one-logo-light.svg
+# NEXT_PUBLIC_NETWORK_LOGO_DARK=https://raw.githubusercontent.com/blockscout/frontend-configs/main/configs/network-logos/arbitrum-one-logo-dark.svg
+NEXT_PUBLIC_NETWORK_NAME=CROSS TESTNET
+# NEXT_PUBLIC_NETWORK_RPC_URL=http://testnet.crossops.in:22001
+NEXT_PUBLIC_NETWORK_SHORT_NAME=CROSS TESTNET
+# NEXT_PUBLIC_OG_ENHANCED_DATA_ENABLED=true
+# NEXT_PUBLIC_OG_IMAGE_URL=https://raw.githubusercontent.com/blockscout/frontend-configs/main/configs/og-images/arbitrum-one.png
+# NEXT_PUBLIC_ROLLUP_L1_BASE_URL=https://eth.blockscout.com
+# NEXT_PUBLIC_ROLLUP_TYPE=arbitrum
+# NEXT_PUBLIC_TRANSACTION_INTERPRETATION_PROVIDER=blockscout
+# NEXT_PUBLIC_VIEWS_CONTRACT_SOLIDITYSCAN_ENABLED=true
+# NEXT_PUBLIC_VISUALIZE_API_HOST=https://visualizer.services.blockscout.com


### PR DESCRIPTION
## Description and Related Issue(s)
Added testnet environment configuration file to support testnet deployment and customization.

### Proposed Changes
- Added new `.env.testnet` file with the following configurations:
 - Set appropriate API endpoints for testnet
 - Configure testnet-specific footer links
 - Set NEXT_PUBLIC_FOOTER_LINKS to:
   ```
   NEXT_PUBLIC_FOOTER_LINKS=https://raw.githubusercontent.com/to-nexus/blockscout-frontend-cross/refs/heads/feature%2Fadd-tps-widget/configs/footer-links/cross.json
   ```
 - Other testnet-specific environment variables